### PR TITLE
Normalize inbound parsing for X-UI clients

### DIFF
--- a/routex_bot/services/xui_client.py
+++ b/routex_bot/services/xui_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import deque
 from typing import Any, Dict, Iterable
 
 import httpx
@@ -69,38 +70,56 @@ class XUIClient:
         if not obj:
             return None
 
-        def _iter_clients(items: Iterable[Any]) -> Iterable[Dict[str, Any]]:
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                stats = item.get("clientStats")
-                if isinstance(stats, list):
-                    for stat in stats:
-                        if isinstance(stat, dict):
-                            yield stat
-                settings = item.get("settings")
-                if isinstance(settings, str):
-                    try:
-                        settings = json.loads(settings)
-                    except json.JSONDecodeError:
-                        settings = None
-                if isinstance(settings, dict):
-                    clients = settings.get("clients")
-                    if isinstance(clients, list):
-                        for client in clients:
-                            if isinstance(client, dict):
-                                yield client
+        def _iter_inbounds(root: Any) -> Iterable[Dict[str, Any]]:
+            """Yield inbound entries regardless of the wrapper structure."""
+
+            queue: deque[Any] = deque([root])
+            while queue:
+                current = queue.popleft()
+                if isinstance(current, list):
+                    for item in current:
+                        if isinstance(item, dict):
+                            queue.append(item)
+                elif isinstance(current, dict):
+                    if "settings" in current or "clientStats" in current:
+                        yield current
+                    for key in ("data", "inbounds", "items", "pageData", "list"):
+                        value = current.get(key)
+                        if isinstance(value, dict):
+                            queue.append(value)
+                        elif isinstance(value, list):
+                            queue.append(value)
+
+        def _iter_clients_from_inbound(inbound: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+            stats = inbound.get("clientStats")
+            if isinstance(stats, list):
+                for stat in stats:
+                    if isinstance(stat, dict):
+                        yield stat
+            settings = inbound.get("settings")
+            if isinstance(settings, str):
+                try:
+                    settings = json.loads(settings)
+                except json.JSONDecodeError:
+                    settings = None
+            if isinstance(settings, dict):
+                clients = settings.get("clients")
+                if isinstance(clients, list):
+                    for client in clients:
+                        if isinstance(client, dict):
+                            yield client
 
         def _looks_like_uuid(value: Any) -> bool:
             return isinstance(value, str) and value.count("-") >= 4 and len(value) >= 8
 
-        for client in _iter_clients(obj if isinstance(obj, list) else [obj]):
-            if client.get("remark") != remark:
-                continue
-            for key in ("clientId", "uuid", "id"):
-                candidate = client.get(key)
-                if _looks_like_uuid(candidate):
-                    return candidate
+        for inbound in _iter_inbounds(obj):
+            for client in _iter_clients_from_inbound(inbound):
+                if client.get("remark") != remark:
+                    continue
+                for key in ("clientId", "uuid", "id"):
+                    candidate = client.get(key)
+                    if _looks_like_uuid(candidate):
+                        return candidate
         return None
 
     @retry(

--- a/tests/test_xui_client.py
+++ b/tests/test_xui_client.py
@@ -1,0 +1,94 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from routex_bot.services.xui_client import XUIClient
+
+
+class DummyResponse:
+    def __init__(self, *, status_code: int = 200, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.headers: dict[str, str] = {}
+        self.text = json.dumps(self._payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class DummyHTTPClient:
+    def __init__(self, response: DummyResponse):
+        self._response = response
+        self.last_request = None
+
+    async def get(self, url: str, *, headers: dict | None = None):
+        self.last_request = {"url": url, "headers": headers or {}}
+        return self._response
+
+
+def test_fetch_client_by_remark_handles_nested_data():
+    client = XUIClient("https://panel", "login", "password")
+    client._session_cookie = "session=abc"
+    payload = {
+        "obj": {
+            "data": {
+                "inbounds": [
+                    {
+                        "clientStats": [
+                            {
+                                "remark": "routex-111",
+                                "uuid": "00000000-0000-0000-0000-000000000111",
+                            },
+                            {
+                                "remark": "routex-222",
+                                "uuid": "00000000-0000-0000-0000-000000000222",
+                            },
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+    client._client = DummyHTTPClient(DummyResponse(payload=payload))
+
+    assert (
+        asyncio.run(client.fetch_client_by_remark(222))
+        == "00000000-0000-0000-0000-000000000222"
+    )
+
+
+def test_fetch_client_by_remark_reads_settings_clients():
+    client = XUIClient("https://panel", "login", "password")
+    client._session_cookie = "session=abc"
+    payload = {
+        "obj": {
+            "data": [
+                {
+                    "settings": json.dumps(
+                        {
+                            "clients": [
+                                {
+                                    "remark": "routex-123",
+                                    "clientId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                                },
+                                {
+                                    "remark": "routex-999",
+                                    "clientId": "ffffffff-1111-2222-3333-444444444444",
+                                },
+                            ]
+                        }
+                    )
+                }
+            ]
+        }
+    }
+    client._client = DummyHTTPClient(DummyResponse(payload=payload))
+
+    assert (
+        asyncio.run(client.fetch_client_by_remark(123))
+        == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    )
+    assert asyncio.run(client.fetch_client_by_remark(321)) is None


### PR DESCRIPTION
## Summary
- normalize `/xui/inbound/list` responses so remark lookups handle wrapped inbound collections
- reuse the existing client parsing logic for each inbound entry before matching remarks
- add regression tests covering nested inbound wrappers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daf17a8670832bb49663b59cc48833