### PR TITLE
Add inbound-aware XUI provisioning and tests

### DIFF
--- a/routex_bot/config.py
+++ b/routex_bot/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
     panel_url: str = Field(..., alias="PANEL_URL")
     panel_login: str = Field(..., alias="PANEL_LOGIN")
     panel_password: str = Field(..., alias="PANEL_PASSWORD")
+    panel_inbound_id: int = Field(..., alias="PANEL_INBOUND_ID")
     events_webhook_token: str = Field(..., alias="EVENTS_WEBHOOK_TOKEN")
     webhook_url: str | None = Field(None, alias="WEBHOOK_URL")
     host: str = Field("0.0.0.0", alias="HOST")

--- a/routex_bot/main.py
+++ b/routex_bot/main.py
@@ -54,7 +54,12 @@ async def main() -> None:
 
     setup_handlers(dp, set(settings.admin_ids))
 
-    xui_client = XUIClient(settings.panel_url, settings.panel_login, settings.panel_password)
+    xui_client = XUIClient(
+        settings.panel_url,
+        settings.panel_login,
+        settings.panel_password,
+        settings.panel_inbound_id,
+    )
     broadcast_service = BroadcastService(
         bot,
         db,

--- a/routex_bot/services/xui_client.py
+++ b/routex_bot/services/xui_client.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Iterable
+import uuid
+from typing import Any, Dict, Iterable, List
 
 import httpx
 from tenacity import RetryError, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -15,13 +16,62 @@ class XUIError(Exception):
     """Raised when X-UI API returns an unexpected response."""
 
 
+def _looks_like_uuid(value: Any) -> bool:
+    return isinstance(value, str) and value.count("-") >= 4 and len(value) >= 8
+
+
+def _iter_client_dicts(obj: Any) -> Iterable[Dict[str, Any]]:
+    items: Iterable[Any]
+    if isinstance(obj, list):
+        items = obj
+    else:
+        items = [obj]
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        client_stats = item.get("clientStats")
+        if isinstance(client_stats, list):
+            for stat in client_stats:
+                if isinstance(stat, dict):
+                    yield stat
+        settings = item.get("settings")
+        if isinstance(settings, str):
+            try:
+                settings = json.loads(settings)
+            except json.JSONDecodeError:
+                settings = None
+        if isinstance(settings, dict):
+            clients = settings.get("clients")
+            if isinstance(clients, list):
+                for client in clients:
+                    if isinstance(client, dict):
+                        yield client
+        yield item
+
+
+def _extract_client_key(payload: Any, remark: str | None = None) -> str | None:
+    if isinstance(payload, dict) and "obj" in payload:
+        key = _extract_client_key(payload.get("obj"), remark)
+        if key:
+            return key
+    for client in _iter_client_dicts(payload):
+        if remark is not None and client.get("remark") != remark:
+            continue
+        for key_name in ("clientId", "uuid", "id"):
+            candidate = client.get(key_name)
+            if _looks_like_uuid(candidate):
+                return candidate
+    return None
+
+
 class XUIClient:
     """Thin wrapper around X-UI/py3xui HTTP API."""
 
-    def __init__(self, base_url: str, login: str, password: str) -> None:
+    def __init__(self, base_url: str, login: str, password: str, inbound_id: int) -> None:
         self.base_url = base_url.rstrip("/")
         self.login = login
         self.password = password
+        self.inbound_id = inbound_id
         self._client = httpx.AsyncClient(timeout=10.0)
         self._session_cookie: str | None = None
 
@@ -65,43 +115,7 @@ class XUIClient:
             payload = response.json()
         except json.JSONDecodeError as exc:  # pragma: no cover - defensive
             raise XUIError("Панель вернула некорректный JSON при поиске клиента") from exc
-        obj = payload.get("obj") if isinstance(payload, dict) else None
-        if not obj:
-            return None
-
-        def _iter_clients(items: Iterable[Any]) -> Iterable[Dict[str, Any]]:
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                stats = item.get("clientStats")
-                if isinstance(stats, list):
-                    for stat in stats:
-                        if isinstance(stat, dict):
-                            yield stat
-                settings = item.get("settings")
-                if isinstance(settings, str):
-                    try:
-                        settings = json.loads(settings)
-                    except json.JSONDecodeError:
-                        settings = None
-                if isinstance(settings, dict):
-                    clients = settings.get("clients")
-                    if isinstance(clients, list):
-                        for client in clients:
-                            if isinstance(client, dict):
-                                yield client
-
-        def _looks_like_uuid(value: Any) -> bool:
-            return isinstance(value, str) and value.count("-") >= 4 and len(value) >= 8
-
-        for client in _iter_clients(obj if isinstance(obj, list) else [obj]):
-            if client.get("remark") != remark:
-                continue
-            for key in ("clientId", "uuid", "id"):
-                candidate = client.get(key)
-                if _looks_like_uuid(candidate):
-                    return candidate
-        return None
+        return _extract_client_key(payload, remark)
 
     @retry(
         retry=retry_if_exception_type((httpx.HTTPError, XUIError)),
@@ -114,10 +128,30 @@ class XUIClient:
 
         await self.ensure_logged_in()
         headers = {"Cookie": self._session_cookie} if self._session_cookie else {}
+        remark = f"routex-{tg_id}"
+        client_uuid = str(uuid.uuid4())
+        settings_payload: Dict[str, List[Dict[str, Any]]] = {
+            "clients": [
+                {
+                    "id": client_uuid,
+                    "uuid": client_uuid,
+                    "email": remark,
+                    "remark": remark,
+                    "enable": True,
+                    "flow": "",
+                    "limitIp": 0,
+                    "totalGB": 0,
+                    "expiryTime": 0,
+                    "alterId": 0,
+                }
+            ]
+        }
         payload = {
-            "remark": f"routex-{tg_id}",
+            "id": self.inbound_id,
+            "remark": remark,
             "enable": True,
             "expiryTime": 0,
+            "settings": json.dumps(settings_payload),
         }
         response = await self._client.post(
             f"{self.base_url}/xui/inbound/addClient",
@@ -126,8 +160,11 @@ class XUIClient:
         )
         if response.status_code not in {200, 201}:
             raise XUIError(f"Ошибка панели: {response.status_code} {response.text}")
-        data = response.json()
-        key = data.get("obj", {}).get("clientId") or data.get("obj", {}).get("uuid")
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:
+            raise XUIError("Панель вернула некорректный JSON при создании клиента") from exc
+        key = _extract_client_key(data, remark)
         if not key:
             raise XUIError("Панель не вернула ключ клиента")
         return key

--- a/tests/test_xui_client.py
+++ b/tests/test_xui_client.py
@@ -1,0 +1,117 @@
+"""Tests for the XUI client integration."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import uuid
+from typing import Any, Dict
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+from routex_bot.db import Database
+from routex_bot.services.xui_client import XUIClient, ensure_or_create_key
+
+
+class _MockResponse:
+    def __init__(self, status_code: int, payload: Dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class XUIClientCreateTests(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.client = XUIClient("https://panel", "user", "pass", inbound_id=77)
+        self.client._session_cookie = "sid=123"  # bypass login
+        self.addAsyncCleanup(self.client.close)
+
+    async def test_create_client_sends_settings_and_returns_uuid(self) -> None:
+        expected_uuid = "11111111-2222-3333-4444-555555555555"
+        remark = "routex-12345"
+        response_payload = {
+            "obj": {
+                "clientStats": [{"clientId": expected_uuid, "remark": remark}],
+                "settings": json.dumps(
+                    {
+                        "clients": [
+                            {
+                                "id": expected_uuid,
+                                "uuid": expected_uuid,
+                                "remark": remark,
+                            }
+                        ]
+                    }
+                ),
+            }
+        }
+        mock_response = _MockResponse(200, response_payload)
+
+        with patch("routex_bot.services.xui_client.uuid.uuid4", return_value=uuid.UUID(expected_uuid)):
+            self.client._client.post = AsyncMock(return_value=mock_response)
+            key = await self.client.create_client(12345)
+
+        self.assertEqual(key, expected_uuid)
+        self.client._client.post.assert_awaited_once()
+        _, kwargs = self.client._client.post.call_args
+        self.assertEqual(kwargs["headers"], {"Cookie": "sid=123"})
+        request_payload = kwargs["json"]
+        self.assertEqual(request_payload["id"], 77)
+        self.assertEqual(request_payload["remark"], remark)
+        self.assertTrue(request_payload["enable"])
+        settings = json.loads(request_payload["settings"])
+        client_settings = settings["clients"][0]
+        self.assertEqual(client_settings["id"], expected_uuid)
+        self.assertEqual(client_settings["uuid"], expected_uuid)
+        self.assertEqual(client_settings["remark"], remark)
+
+
+class EnsureOrCreateKeyTests(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        db_path = os.path.join(self.tmpdir.name, "test.sqlite3")
+        self.db = Database(db_path)
+        await self.db.connect()
+        await self.db.init_models()
+        self.addAsyncCleanup(self.db.close)
+
+        self.client = XUIClient("https://panel", "user", "pass", inbound_id=42)
+        self.client._session_cookie = "sid=abc"
+        self.addAsyncCleanup(self.client.close)
+
+    async def test_ensure_or_create_key_creates_remote_client(self) -> None:
+        expected_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        remark = "routex-999"
+        response_payload = {
+            "obj": {
+                "clientStats": [{"clientId": expected_uuid, "remark": remark}],
+                "settings": json.dumps(
+                    {
+                        "clients": [
+                            {
+                                "id": expected_uuid,
+                                "uuid": expected_uuid,
+                                "remark": remark,
+                            }
+                        ]
+                    }
+                ),
+            }
+        }
+        mock_response = _MockResponse(200, response_payload)
+        self.client._client.post = AsyncMock(return_value=mock_response)
+        self.client.fetch_client_by_remark = AsyncMock(return_value=None)
+
+        with patch("routex_bot.services.xui_client.uuid.uuid4", return_value=uuid.UUID(expected_uuid)):
+            key = await ensure_or_create_key(self.db, self.client, 999)
+
+        self.assertEqual(key, expected_uuid)
+        self.client._client.post.assert_awaited_once()
+        user = await self.db.get_user(999)
+        assert user is not None
+        self.assertEqual(user["key"], expected_uuid)


### PR DESCRIPTION
## Summary
- add the panel inbound id to configuration and wire it through the XUI client
- send inbound id with encoded client settings when provisioning users and harden key parsing
- add async unit tests that mock the addClient API to verify key creation end to end

## Testing
- python -m unittest discover tests

------
https://chatgpt.com/codex/tasks/task_e_68daf17bddec832b84edf22f85d2ace5